### PR TITLE
Add support for Tsung 1.7

### DIFF
--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -1,0 +1,18 @@
+FROM erlang:18
+
+MAINTAINER Andrea Usuelli <andreausu@gmail.com>
+
+RUN apt-get update && \
+    apt-get install -y python perl libtemplate-perl gnuplot && \
+    curl http://tsung.erlang-projects.org/dist/tsung-1.7.0.tar.gz --output /tmp/tsung-1.7.0.tar.gz \
+    && cd /tmp/ \
+    && tar xzf ./tsung-1.7.0.tar.gz \
+    && cd tsung-1.7.0 \
+    && ./configure \
+    && make \
+    && make install \
+    && rm -rf /tmp/tsung*
+
+EXPOSE 8091
+
+ENTRYPOINT ["tsung"]


### PR DESCRIPTION
This copies the 1.6 Dockerfile into a 1.7 variant.

I've not updated the Readme, as that would require an image to be published. This is outside of my capabilities.